### PR TITLE
Replace unaligned ref with raw pointer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MIT
 
 #![no_std]
-#![feature(core_intrinsics)]
-
-#![allow(dead_code)]
 
 #[macro_use]
 extern crate bitflags;
@@ -94,6 +91,7 @@ bitflags! {
     }
 }
 
+#[allow(dead_code)]
 impl HsfStsCtl {
     fn sanitize(&mut self) {
         // FDONE, FCERR, and H_AEL are cleared if one is written, so they are left untouched


### PR DESCRIPTION
Unaligned references currently create a warning, and will be a hard error in the future. Use the `addr_of!()` macro to create a raw pointer without creating an intermediate reference.

Remove `Mmio::new()` as it is unsound. These values should only be constructed by transmuting memory.

Replace the `core_instrinsic` feature with the stabilized `{read,write}_volatile()` in `core::ptr`.

Tested by flashing gaze15 and booting.

---

`addr_of!()` requires 1.51.0+. We will need to update the toolchain in firmware-open when updating this submodule.