### PR TITLE
Read SPI BAR through PCIe BAR

### DIFF
--- a/examples/read.rs
+++ b/examples/read.rs
@@ -9,7 +9,7 @@ use std::fs;
 mod util;
 
 fn main() {
-    let spi = unsafe { util::get_spi() };
+    let mut spi = unsafe { util::get_spi() };
 
     eprintln!("SPI HSFSTS_CTL: {:?}", spi.hsfsts_ctl());
 
@@ -27,6 +27,4 @@ fn main() {
     eprintln!();
 
     fs::write("read.rom", &data).unwrap();
-
-    unsafe { util::release_spi(spi); }
 }

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -11,7 +11,7 @@ mod util;
 fn main() {
     let mut spi = unsafe { util::get_spi() };
 
-    eprintln!("SPI HSFSTS_CTL: {:?}", spi.hsfsts_ctl());
+    eprintln!("SPI HSFSTS_CTL: {:?}", spi.regs.hsfsts_ctl());
 
     let len = spi.len().unwrap();
     eprintln!("SPI ROM: {} KB", len / 1024);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,16 +341,21 @@ impl SpiRegs {
 
 impl Spi for SpiRegs {
     fn len(&mut self) -> Result<usize, SpiError> {
+        let kib = 1024;
+        let mib = 1024 * kib;
+
         let component = self.fdo(FdoSection::Component, 0);
         Ok(match component & 0b111 {
-            0b000 => 512,
-            0b001 => 1024,
-            0b010 => 2048,
-            0b011 => 4096,
-            0b100 => 8192,
-            0b101 => 16384,
+            0b000 => 512 * kib,
+            0b001 => mib,
+            0b010 => 2 * mib,
+            0b011 => 4 * mib,
+            0b100 => 8 * mib,
+            0b101 => 16 * mib,
+            0b110 => 32 * mib,
+            0b111 => 64 * mib,
             _ => return Err(SpiError::Register)
-        } * 1024)
+        })
     }
 
     fn read(&mut self, address: usize, buf: &mut [u8]) -> Result<usize, SpiError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,9 +56,9 @@ fn main() {
         }
     };
 
-    let spi = unsafe { util::get_spi() };
+    let mut spi = unsafe { util::get_spi() };
 
-    eprintln!("SPI HSFSTS_CTL: {:?}", spi.hsfsts_ctl());
+    eprintln!("SPI HSFSTS_CTL: {:?}", spi.regs.hsfsts_ctl());
 
     // Read new data
     let mut new;
@@ -277,6 +277,4 @@ fn main() {
         }
         eprintln!();
     }
-
-    unsafe { util::release_spi(spi); }
 }

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -1,0 +1,32 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct PhysicalAddress(pub usize);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct VirtualAddress(pub usize);
+
+pub trait Mapper {
+    unsafe fn map_aligned(&mut self, address: PhysicalAddress, size: usize) -> Result<VirtualAddress, &'static str>;
+    unsafe fn unmap_aligned(&mut self, address: VirtualAddress, size: usize) -> Result<(), &'static str>;
+    fn page_size(&self) -> usize;
+
+    unsafe fn map(&mut self, address: PhysicalAddress, size: usize) -> Result<VirtualAddress, &'static str> {
+        let page_size = self.page_size();
+        let page = address.0/page_size;
+        let aligned_address = PhysicalAddress(page * page_size);
+        let offset = address.0 - aligned_address.0;
+        let pages = (offset + size + page_size - 1) / page_size;
+        let aligned_size = pages * page_size;
+        let virtual_address = self.map_aligned(aligned_address, aligned_size)?;
+        Ok(VirtualAddress(virtual_address.0 + offset))
+    }
+
+    unsafe fn unmap(&mut self, address: VirtualAddress, size: usize) -> Result<(), &'static str> {
+        let page_size = self.page_size();
+        let page = address.0/page_size;
+        let aligned_address = VirtualAddress(page * page_size);
+        let offset = address.0 - aligned_address.0;
+        let pages = (offset + size + page_size - 1) / page_size;
+        let aligned_size = pages * page_size;
+        self.unmap_aligned(aligned_address, aligned_size)
+    }
+}


### PR DESCRIPTION
This removes the hardcoded SPI BAR, which is not valid on ADL. By using MCFG, we are able to read from memory mapped PCIe configuration space without the race conditions port mapped configuration space has. Also, the SPI device is now checked against a list of supported IDs.