### PR TITLE
Remove use of `repr(packed)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ pub enum FdoSection {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C)]
 pub struct SpiRegs {
     /// BIOS Flash Primary Region
     bfpreg: Mmio<u32>,

--- a/src/mmio.rs
+++ b/src/mmio.rs
@@ -5,7 +5,7 @@ use core::ptr;
 
 use super::io::Io;
 
-#[repr(packed)]
+#[repr(transparent)]
 pub struct Mmio<T> {
     value: T
 }
@@ -14,12 +14,10 @@ impl<T> Io for Mmio<T> where T: Copy + PartialEq + BitAnd<Output = T> + BitOr<Ou
     type Value = T;
 
     fn read(&self) -> T {
-        let raw = ptr::addr_of!(self.value);
-        unsafe { raw.read_volatile() }
+        unsafe { ptr::read_volatile(&self.value) }
     }
 
     fn write(&mut self, value: T) {
-        let raw = ptr::addr_of_mut!(self.value);
-        unsafe { raw.write_volatile(value) };
+        unsafe { ptr::write_volatile(&mut self.value, value) };
     }
 }


### PR DESCRIPTION
MMIO devices are aligned to a 4 KiB boundary and with a size granularity of 4 KiB. The SPI memory mapped registers are all 4 byte aligned `u32`s. This makes `packed` unnecessary.

`Mmio` is left as a wrapper for the volatile reads/writes.

Ref: Intel CPU EDS Vol 2, PCI Express I/O Address Mapping
Ref: Intel PCH Datasheet Vol 2, SPI Interface (D31:F5)

From section "PCI Express I/O Address Mapping":

> Address decoding for this range is based on the following concept. The top 4 bits of the
> respective I/O Base and I/O Limit registers correspond to address bits A[15:12] of an
> I/O address. For the purpose of address decoding, the device assumes that the lower
> 12 address bits A[11:0] of the I/O base are zero and that address bits A[11:0] of the I/O
> limit address are FFFh. This forces the I/O address range alignment to a 4 KB
> boundary and produces a size granularity of 4 KB.

Test:

- flashing firmware-open boards works, and they successfully boot